### PR TITLE
fix(dependabot): remove obsolete ignore list for go packages

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,10 +7,6 @@ updates:
       include: "scope"
       prefix: "chore(deps)"
     directory: "/"
-    ignore:
-      # newer versions of these libs will break build
-      - dependency-name: "k8s.io/api"
-      - dependency-name: "k8s.io/apimachinery"
     open-pull-requests-limit: 10
     package-ecosystem: "gomod"
     schedule:


### PR DESCRIPTION
Follow #1677

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Now that we support the latest versions of `k8s.io/api` and `k8s.io/apimachinery`, we can safely use dependabot to follow latest updates for these dependencies.